### PR TITLE
Borre carpeta que cree por error

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "MEDI",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Por error instale algunas librerias en el direccion incorrecta y se creo la carpeta node_modules donde no deberia estar.